### PR TITLE
docs: 飞书配置指南

### DIFF
--- a/飞书配置指南.md
+++ b/飞书配置指南.md
@@ -1,0 +1,216 @@
+# 飞书配置指南
+
+AI 朝廷支持飞书作为通讯渠道，无需公网 IP，使用 WebSocket 长连接接收消息。
+
+## 前置条件
+
+- 已通过 `install.sh` 或 `install-lite.sh` 完成基础安装
+- OpenClaw 已安装（`openclaw --version` 能正常输出）
+
+## 第一步：创建飞书应用
+
+### 1. 打开飞书开放平台
+
+访问 [https://open.feishu.cn/app](https://open.feishu.cn/app) 并登录。
+
+> 如果是 Lark（国际版），访问 [https://open.larksuite.com/app](https://open.larksuite.com/app)
+
+### 2. 创建企业自建应用
+
+- 点击 **创建企业自建应用**
+- 填写应用名称（如 "AI朝廷-司礼监"）和描述
+- 选择一个应用图标
+
+### 3. 复制凭证
+
+在 **凭证与基础信息** 页面，复制：
+- **App ID**（格式：`cli_xxx`）
+- **App Secret**
+
+⚠️ App Secret 请妥善保管，不要泄露。
+
+### 4. 配置权限
+
+在 **权限管理** 页面，点击 **批量导入**，粘贴以下 JSON：
+
+```json
+{
+  "scopes": {
+    "tenant": [
+      "im:message",
+      "im:message.group_at_msg:readonly",
+      "im:message.p2p_msg:readonly",
+      "im:message:readonly",
+      "im:message:send_as_bot",
+      "im:resource",
+      "im:chat.members:bot_access",
+      "im:chat.access_event.bot_p2p_chat:read",
+      "contact:user.employee_id:readonly"
+    ],
+    "user": [
+      "im:chat.access_event.bot_p2p_chat:read"
+    ]
+  }
+}
+```
+
+### 5. 启用机器人能力
+
+在 **应用能力 > 机器人**：
+- 开启机器人能力
+- 设置机器人名称
+
+### 6. 配置事件订阅
+
+⚠️ **重要：** 先完成第二步（配置 OpenClaw 并启动 Gateway），再回来配置事件订阅！
+
+在 **事件订阅** 中：
+- 选择 **使用长连接接收事件**（WebSocket）
+- 添加事件：`im.message.receive_v1`
+
+### 7. 发布应用
+
+- 在 **版本管理与发布** 中创建版本
+- 提交审核并发布
+- 等待管理员审批（企业自建应用通常自动审批）
+
+## 第二步：配置 OpenClaw
+
+### 方式一：交互式配置（推荐）
+
+```bash
+openclaw channels add
+```
+
+选择 Feishu，然后输入 App ID 和 App Secret。
+
+### 方式二：手动编辑配置文件
+
+编辑 `~/.openclaw/openclaw.json`，在 `channels` 中添加飞书配置：
+
+```json
+{
+  "channels": {
+    "feishu": {
+      "enabled": true,
+      "dmPolicy": "pairing",
+      "accounts": {
+        "main": {
+          "appId": "cli_xxx",
+          "appSecret": "你的App Secret",
+          "botName": "司礼监"
+        }
+      }
+    }
+  }
+}
+```
+
+### 方式三：环境变量
+
+```bash
+export FEISHU_APP_ID="cli_xxx"
+export FEISHU_APP_SECRET="你的App Secret"
+```
+
+## 第三步：启动并验证
+
+```bash
+# 重启 Gateway
+openclaw gateway restart
+
+# 查看状态
+openclaw gateway status
+
+# 查看日志（确认飞书连接成功）
+openclaw logs --follow
+```
+
+日志中应该看到飞书 WebSocket 连接成功的信息。
+
+## 多 Bot 模式（六部）
+
+如果要像 Discord 一样实现多 Bot 六部架构，需要在飞书创建多个应用：
+
+```json
+{
+  "channels": {
+    "feishu": {
+      "enabled": true,
+      "accounts": {
+        "main": {
+          "appId": "cli_主bot",
+          "appSecret": "xxx",
+          "botName": "司礼监"
+        },
+        "bingbu": {
+          "appId": "cli_兵部bot",
+          "appSecret": "xxx",
+          "botName": "兵部"
+        },
+        "gongbu": {
+          "appId": "cli_工部bot",
+          "appSecret": "xxx",
+          "botName": "工部"
+        }
+      }
+    }
+  },
+  "bindings": [
+    { "agentId": "main", "match": { "channel": "feishu", "accountId": "main" } },
+    { "agentId": "bingbu", "match": { "channel": "feishu", "accountId": "bingbu" } },
+    { "agentId": "gongbu", "match": { "channel": "feishu", "accountId": "gongbu" } }
+  ]
+}
+```
+
+> 提示：飞书也可以只用一个 Bot（司礼监），通过 sessions_spawn 调度其他部门。
+
+## Lark 国际版
+
+如果使用 Lark（国际版），在配置中加上 `domain: "lark"`：
+
+```json
+{
+  "channels": {
+    "feishu": {
+      "domain": "lark",
+      "accounts": {
+        "main": {
+          "appId": "cli_xxx",
+          "appSecret": "xxx"
+        }
+      }
+    }
+  }
+}
+```
+
+## 省配额优化（可选）
+
+减少飞书 API 调用量：
+
+```json
+{
+  "channels": {
+    "feishu": {
+      "typingIndicator": false,
+      "resolveSenderNames": false
+    }
+  }
+}
+```
+
+- `typingIndicator: false` — 不发送"正在输入"状态
+- `resolveSenderNames: false` — 不查询发送者姓名
+
+## 常见问题
+
+**Q: 事件订阅保存失败？**
+A: 确保 Gateway 已启动（`openclaw gateway status`），飞书需要验证 WebSocket 连接。
+
+**Q: 机器人收不到消息？**
+A: 检查是否添加了 `im.message.receive_v1` 事件，权限是否都已批准。
+
+**Q: 需要公网 IP 吗？**
+A: 不需要。飞书的 WebSocket 模式是主动连接飞书服务器，不需要公网 IP 或域名。


### PR DESCRIPTION
## 飞书配置教程

社区高频需求（#10，6条评论催更），OpenClaw 已内置飞书插件支持。

### 教程覆盖
- 飞书应用创建全流程（权限 JSON 批量导入、WebSocket 事件订阅）
- 3 种配置方式：交互式 / 配置文件 / 环境变量
- 多 Bot 六部模式飞书版配置示例
- Lark 国际版 domain 配置
- 省配额优化（关闭 typingIndicator / resolveSenderNames）
- 常见问题 FAQ

### 关键信息
- **不需要公网 IP**：飞书 WebSocket 模式主动连接飞书服务器
- **内置插件**：当前版本 OpenClaw 已自带，无需额外安装
- **多 Bot 可选**：可以只用一个 Bot + sessions_spawn 调度

Closes #10