### PR TITLE
feat: Docker 镜像 + OpenViking 知识库集成

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+.git
+*.log
+gui/node_modules
+gui/dist
+evidence/
+images/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,50 @@
+FROM node:22-slim
+
+LABEL maintainer="wanikua" \
+      description="AI 朝廷一键部署 Docker 镜像" \
+      org.opencontainers.image.source="https://github.com/wanikua/boluobobo-ai-court-tutorial"
+
+# 系统依赖
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends \
+        curl git ca-certificates gnupg \
+        chromium python3 python3-pip python3-venv && \
+    # gh CLI
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+        | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg 2>/dev/null && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] \
+        https://cli.github.com/packages stable main" \
+        > /etc/apt/sources.list.d/github-cli.list && \
+    apt-get update -qq && apt-get install -y --no-install-recommends gh && \
+    # 清理
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Chromium 路径
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+
+# OpenClaw
+RUN npm install -g openclaw --loglevel=error
+
+# OpenViking（Python 依赖）
+RUN python3 -m venv /opt/openviking && \
+    /opt/openviking/bin/pip install --no-cache-dir openviking && \
+    ln -s /opt/openviking/bin/openviking /usr/local/bin/openviking 2>/dev/null || true
+ENV PATH="/opt/openviking/bin:$PATH"
+
+# 工作区
+RUN mkdir -p /root/clawd/memory /root/clawd/skills /root/.openclaw
+WORKDIR /root/clawd
+
+# 复制朝廷模板文件
+COPY docker/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+# 复制 skill 和模板
+COPY skills/ /root/clawd/skills/
+
+# 端口：Gateway WebUI
+EXPOSE 18789
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["openclaw", "gateway", "--verbose"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+version: '3.8'
+
+services:
+  court:
+    build: .
+    image: ai-court:latest
+    container_name: ai-court
+    restart: unless-stopped
+    ports:
+      - "18789:18789"   # Gateway WebUI
+    volumes:
+      # 配置文件（必须挂载）
+      - ./openclaw.json:/root/.openclaw/openclaw.json
+      # 工作区持久化（记忆、日志等）
+      - court-workspace:/root/clawd
+      # OpenViking 数据持久化（可选）
+      - court-openviking:/root/.openviking
+    environment:
+      # LLM API Key（也可以写在 openclaw.json 里）
+      - LLM_API_KEY=${LLM_API_KEY:-}
+      # OpenViking 配置（可选）
+      - OPENVIKING_CONFIG_FILE=${OPENVIKING_CONFIG_FILE:-}
+    # 健康检查
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:18789/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+
+volumes:
+  court-workspace:
+  court-openviking:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+set -e
+
+WORKSPACE="/root/clawd"
+CONFIG_DIR="/root/.openclaw"
+
+# ---- 初始化工作区模板（仅首次）----
+if [ ! -f "$WORKSPACE/SOUL.md" ]; then
+cat > "$WORKSPACE/SOUL.md" << 'EOF'
+# SOUL.md - 朝廷行为准则
+
+## 铁律
+1. 废话不要多 — 说重点
+2. 汇报要及时 — 做完就说
+3. 做事要靠谱 — 先想后做
+
+## 沟通风格
+- 中文为主
+- 直接说结论，需要细节再展开
+EOF
+echo "✓ SOUL.md 已创建"
+fi
+
+if [ ! -f "$WORKSPACE/IDENTITY.md" ]; then
+cat > "$WORKSPACE/IDENTITY.md" << 'EOF'
+# IDENTITY.md - 朝廷架构
+
+## 六部
+- 兵部：软件工程、系统架构
+- 户部：财务预算、电商运营
+- 礼部：品牌营销、内容创作
+- 工部：DevOps、服务器运维
+- 吏部：项目管理、创业孵化
+- 刑部：法务合规、知识产权
+EOF
+echo "✓ IDENTITY.md 已创建"
+fi
+
+if [ ! -f "$WORKSPACE/USER.md" ]; then
+cat > "$WORKSPACE/USER.md" << 'EOF'
+# USER.md - 关于你
+
+- **称呼:** （填你的称呼）
+- **语言:** 中文
+- **风格:** 简洁高效
+EOF
+echo "✓ USER.md 已创建"
+fi
+
+mkdir -p "$WORKSPACE/memory"
+
+# ---- OpenViking 初始化（如果配置了）----
+if [ -f "/root/.openviking/ov.conf" ] || [ -n "$OPENVIKING_CONFIG_FILE" ]; then
+    echo "✓ OpenViking 配置已检测到"
+    # 确保 OpenViking 数据目录存在
+    mkdir -p /root/.openviking/data
+fi
+
+# ---- 提示信息 ----
+if [ ! -f "$CONFIG_DIR/openclaw.json" ]; then
+    echo ""
+    echo "================================"
+    echo "⚠ 配置文件不存在"
+    echo "================================"
+    echo ""
+    echo "请挂载配置文件或设置环境变量："
+    echo ""
+    echo "  方式一：挂载配置文件"
+    echo "    docker run -v ./openclaw.json:/root/.openclaw/openclaw.json ..."
+    echo ""
+    echo "  方式二：交互式配置"
+    echo "    docker exec -it <容器名> openclaw onboard"
+    echo ""
+    echo "  方式三：添加单个渠道"
+    echo "    docker exec -it <容器名> openclaw channels add"
+    echo ""
+fi
+
+echo ""
+echo "🏛️ AI 朝廷 Docker 启动中..."
+echo "  工作区: $WORKSPACE"
+echo "  配置: $CONFIG_DIR/openclaw.json"
+echo "  WebUI: http://localhost:18789"
+echo ""
+
+exec "$@"

--- a/skills/openviking/SKILL.md
+++ b/skills/openviking/SKILL.md
@@ -1,0 +1,99 @@
+# OpenViking Skill
+
+OpenViking 上下文数据库集成 — 给 AI 朝廷加上长期记忆和知识库。
+
+## 什么是 OpenViking
+
+OpenViking 是火山引擎开源的 AI Agent 上下文数据库，用文件系统范式统一管理记忆、资源和技能。
+相比 OpenClaw 默认的 qmd 记忆后端，OpenViking 在大规模文档场景下更强：
+
+| 能力 | qmd（默认） | OpenViking |
+|------|-----------|------------|
+| 语义搜索 | 基础向量匹配 | 目录递归 + 语义融合 |
+| 自动摘要 | ❌ | ✅ L0/L1/L2 三层 |
+| 结构化浏览 | ❌ | ✅ 虚拟文件系统 |
+| Token 节省 | ❌ | ✅ 按需加载 |
+
+## 安装
+
+### 1. 安装 Python 包
+
+```bash
+pip install openviking
+```
+
+### 2. 获取 Embedding API Key
+
+推荐使用免费的 NVIDIA NIM API：
+
+1. 访问 https://build.nvidia.com/
+2. 登录 → API Keys → 生成 Key
+3. 保存 key（以 `nvapi-` 开头）
+
+也可以用火山引擎、OpenAI 等其他 provider。
+
+### 3. 创建配置文件
+
+```bash
+mkdir -p ~/.openviking
+cat > ~/.openviking/ov.conf << 'EOF'
+{
+  "embedding": {
+    "dense": {
+      "api_base": "https://integrate.api.nvidia.com/v1",
+      "api_key": "YOUR_NVIDIA_API_KEY",
+      "provider": "openai",
+      "dimension": 4096,
+      "model": "nvidia/nv-embed-v1"
+    }
+  },
+  "vlm": {
+    "api_base": "https://integrate.api.nvidia.com/v1",
+    "api_key": "YOUR_NVIDIA_API_KEY",
+    "provider": "openai",
+    "model": "meta/llama-3.3-70b-instruct"
+  }
+}
+EOF
+```
+
+### 4. 设置环境变量
+
+```bash
+echo 'export OPENVIKING_CONFIG_FILE=~/.openviking/ov.conf' >> ~/.bashrc
+source ~/.bashrc
+```
+
+## 使用方式
+
+Agent 通过 exec 调用 `scripts/viking.sh` 脚本：
+
+```bash
+# 查看状态
+bash skills/openviking/scripts/viking.sh info
+
+# 索引文件
+bash skills/openviking/scripts/viking.sh add ./my-document.md
+
+# 批量索引目录
+bash skills/openviking/scripts/viking.sh add-dir ./docs/
+
+# 语义搜索
+bash skills/openviking/scripts/viking.sh search "某个话题"
+
+# 浏览已索引的文件
+bash skills/openviking/scripts/viking.sh list
+
+# 读取文件摘要
+bash skills/openviking/scripts/viking.sh summary <file-path>
+```
+
+## 朝廷集成建议
+
+- **兵部**：索引代码仓库，搜索相关代码片段
+- **户部**：索引财务报表，查询历史数据
+- **礼部**：索引品牌素材和营销案例
+- **工部**：索引运维文档和 runbook
+- **刑部**：索引法律法规和合同模板
+
+建议保留 qmd 做日常轻量记忆，OpenViking 做大规模知识库。

--- a/skills/openviking/scripts/viking.sh
+++ b/skills/openviking/scripts/viking.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+# OpenViking CLI 封装脚本
+# 用法: bash viking.sh <command> [args...]
+
+set -e
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+# 检查 openviking 是否安装
+if ! command -v openviking &>/dev/null && ! python3 -c "import openviking" &>/dev/null 2>&1; then
+    echo -e "${RED}✗ OpenViking 未安装${NC}"
+    echo "运行: pip install openviking"
+    exit 1
+fi
+
+# 检查配置
+OV_CONF="${OPENVIKING_CONFIG_FILE:-$HOME/.openviking/ov.conf}"
+if [ ! -f "$OV_CONF" ]; then
+    echo -e "${RED}✗ OpenViking 配置文件不存在: $OV_CONF${NC}"
+    echo "请参考 skills/openviking/SKILL.md 创建配置"
+    exit 1
+fi
+
+OV_DATA="${OPENVIKING_DATA_DIR:-$HOME/.openviking/data}"
+mkdir -p "$OV_DATA"
+
+CMD="${1:-help}"
+shift 2>/dev/null || true
+
+case "$CMD" in
+    info)
+        echo -e "${GREEN}OpenViking 状态${NC}"
+        echo "  配置: $OV_CONF"
+        echo "  数据: $OV_DATA"
+        python3 -c "import openviking; print(f'  版本: {openviking.__version__}')" 2>/dev/null || echo "  版本: unknown"
+        if [ -d "$OV_DATA" ]; then
+            FILE_COUNT=$(find "$OV_DATA" -type f 2>/dev/null | wc -l)
+            echo "  已索引文件: $FILE_COUNT"
+        fi
+        ;;
+    add)
+        if [ -z "$1" ]; then
+            echo -e "${RED}用法: viking.sh add <file-path>${NC}"
+            exit 1
+        fi
+        echo -e "${YELLOW}索引文件: $1${NC}"
+        python3 -c "
+from openviking import Viking
+v = Viking.from_config('$OV_CONF')
+v.add_resource('$1', data_dir='$OV_DATA')
+print('✓ 索引完成')
+" 2>&1
+        ;;
+    add-dir)
+        DIR="${1:-.}"
+        echo -e "${YELLOW}批量索引目录: $DIR${NC}"
+        python3 -c "
+import os
+from openviking import Viking
+v = Viking.from_config('$OV_CONF')
+count = 0
+for root, dirs, files in os.walk('$DIR'):
+    for f in files:
+        if f.endswith(('.md', '.txt', '.py', '.js', '.ts', '.json', '.yaml', '.yml', '.sh', '.html', '.css')):
+            path = os.path.join(root, f)
+            try:
+                v.add_resource(path, data_dir='$OV_DATA')
+                count += 1
+                print(f'  ✓ {path}')
+            except Exception as e:
+                print(f'  ✗ {path}: {e}')
+print(f'\n共索引 {count} 个文件')
+" 2>&1
+        ;;
+    search)
+        if [ -z "$1" ]; then
+            echo -e "${RED}用法: viking.sh search <query>${NC}"
+            exit 1
+        fi
+        QUERY="$*"
+        python3 -c "
+from openviking import Viking
+v = Viking.from_config('$OV_CONF')
+results = v.search('$QUERY', data_dir='$OV_DATA', top_k=5)
+if not results:
+    print('无匹配结果')
+else:
+    for i, r in enumerate(results, 1):
+        score = getattr(r, 'score', 0)
+        path = getattr(r, 'path', getattr(r, 'source', 'unknown'))
+        content = getattr(r, 'content', getattr(r, 'text', ''))[:200]
+        print(f'{i}. [{score:.3f}] {path}')
+        print(f'   {content}')
+        print()
+" 2>&1
+        ;;
+    list)
+        echo -e "${GREEN}已索引的文件：${NC}"
+        python3 -c "
+from openviking import Viking
+v = Viking.from_config('$OV_CONF')
+resources = v.list_resources(data_dir='$OV_DATA')
+if not resources:
+    print('  （空）')
+else:
+    for r in resources:
+        print(f'  {r}')
+" 2>&1
+        ;;
+    summary)
+        if [ -z "$1" ]; then
+            echo -e "${RED}用法: viking.sh summary <file-path>${NC}"
+            exit 1
+        fi
+        python3 -c "
+from openviking import Viking
+v = Viking.from_config('$OV_CONF')
+summary = v.get_summary('$1', data_dir='$OV_DATA')
+print(summary or '无摘要')
+" 2>&1
+        ;;
+    help|*)
+        echo "OpenViking CLI 封装"
+        echo ""
+        echo "用法: bash viking.sh <command> [args]"
+        echo ""
+        echo "命令:"
+        echo "  info              查看 OpenViking 状态"
+        echo "  add <file>        索引单个文件"
+        echo "  add-dir [dir]     批量索引目录（默认当前目录）"
+        echo "  search <query>    语义搜索"
+        echo "  list              列出已索引的文件"
+        echo "  summary <file>    查看文件摘要"
+        echo "  help              显示帮助"
+        ;;
+esac


### PR DESCRIPTION
## Docker 一键部署

用户不再需要手动跑 install.sh，直接 Docker 起：

```bash
# 克隆仓库
git clone https://github.com/wanikua/boluobobo-ai-court-tutorial.git
cd boluobobo-ai-court-tutorial

# 编辑配置
cp openclaw.json.example openclaw.json  # 填入 API Key 和 Bot Token

# 启动
docker compose up -d

# 查看日志
docker compose logs -f
```

### 镜像内容
- `node:22-slim` 基础
- Chromium（浏览器 skill）
- GitHub CLI
- OpenClaw（最新版）
- OpenViking（Python 上下文数据库）

### 持久化
- `court-workspace` — 工作区（记忆、SOUL.md 等）
- `court-openviking` — OpenViking 索引数据
- 配置文件通过 bind mount 挂载

---

## OpenViking 集成

[OpenViking](https://github.com/volcengine/OpenViking)（火山引擎开源，5.6k⭐）是 AI Agent 上下文数据库。

### 新增 Skill
- `skills/openviking/SKILL.md` — 安装教程 + 各部门使用建议
- `skills/openviking/scripts/viking.sh` — CLI 封装
  - `info` 状态 / `add` 索引 / `search` 搜索 / `list` 列表 / `summary` 摘要

### 朝廷集成建议
| 部门 | 用途 |
|------|------|
| 兵部 | 索引代码仓库 |
| 户部 | 索引财务报表 |
| 礼部 | 索引品牌素材 |
| 工部 | 索引运维文档 |
| 刑部 | 索引法律法规 |

保留 qmd 做日常记忆，OpenViking 做知识库，互补使用。