### PR TITLE
fix: 下旨改用 Webhook 以用户身份发送

### DIFF
--- a/gui/server/index.js
+++ b/gui/server/index.js
@@ -1493,18 +1493,61 @@ app.get('/api/bot-user-ids', authMiddleware, async (req, res) => {
   }
 });
 
-// 发送指令到Discord频道（始终用主bot发送，正确@mention目标bot）
+// Webhook 缓存：channelId -> { id, token, url }
+const webhookCache = {};
+
+// 获取或创建频道 Webhook（用于模拟用户身份发消息）
+async function getOrCreateWebhook(channelId, botToken) {
+  // 命中缓存
+  if (webhookCache[channelId]) {
+    return webhookCache[channelId];
+  }
+
+  // 查找已有的 webhook
+  const listRes = await fetch(`https://discord.com/api/v10/channels/${channelId}/webhooks`, {
+    headers: { 'Authorization': `Bot ${botToken}` }
+  });
+  if (listRes.ok) {
+    const webhooks = await listRes.json();
+    // 找我们创建的 webhook
+    const existing = webhooks.find(w => w.name === 'AI朝廷-下旨');
+    if (existing) {
+      const wh = { id: existing.id, token: existing.token, url: `https://discord.com/api/webhooks/${existing.id}/${existing.token}` };
+      webhookCache[channelId] = wh;
+      return wh;
+    }
+  }
+
+  // 创建新 webhook
+  const createRes = await fetch(`https://discord.com/api/v10/channels/${channelId}/webhooks`, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bot ${botToken}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ name: 'AI朝廷-下旨' })
+  });
+  if (!createRes.ok) {
+    const err = await createRes.text();
+    throw new Error(`创建 Webhook 失败: ${err}`);
+  }
+  const wh = await createRes.json();
+  const result = { id: wh.id, token: wh.token, url: `https://discord.com/api/webhooks/${wh.id}/${wh.token}` };
+  webhookCache[channelId] = result;
+  return result;
+}
+
+// 发送指令到Discord频道（通过 Webhook 以用户身份发送）
 app.post('/api/command', authMiddleware, async (req, res) => {
-  const { channel, message, botId, mentionUserId } = req.body;
+  const { channel, message, botId, mentionUserId, username, avatarUrl } = req.body;
   const targetChannel = channel || '1474091579630293164'; // 默认朝堂频道
   
   try {
     const config = JSON.parse(readFileSync(CONFIG_PATH, 'utf-8'));
-    // 始终用主bot（司礼监）的token发送，模拟"用户下旨"
     const mainAccount = config.channels?.discord?.accounts?.['main'];
-    const token = mainAccount?.token;
+    const botToken = mainAccount?.token;
     
-    if (!token) {
+    if (!botToken) {
       return res.status(400).json({ error: 'Main bot token not found' });
     }
 
@@ -1514,20 +1557,29 @@ app.post('/api/command', authMiddleware, async (req, res) => {
       finalMessage = `<@${mentionUserId}> ${message}`;
     }
 
-    const r = await fetch(`https://discord.com/api/v10/channels/${targetChannel}/messages`, {
+    // 通过 Webhook 发送，显示为用户身份
+    const webhook = await getOrCreateWebhook(targetChannel, botToken);
+    const senderName = username || '皇上';
+
+    const r = await fetch(`${webhook.url}?wait=true`, {
       method: 'POST',
-      headers: {
-        'Authorization': `Bot ${token}`,
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({ content: finalMessage })
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        content: finalMessage,
+        username: senderName,
+        ...(avatarUrl ? { avatar_url: avatarUrl } : {})
+      })
     });
     
     if (r.ok) {
       const data = await r.json();
-      res.json({ success: true, messageId: data.id, sentAs: 'main', channel: targetChannel });
+      res.json({ success: true, messageId: data.id, sentAs: senderName, channel: targetChannel });
     } else {
       const err = await r.text();
+      // Webhook 失效时清除缓存重试
+      if (r.status === 404 || r.status === 401) {
+        delete webhookCache[targetChannel];
+      }
       res.status(r.status).json({ error: err });
     }
   } catch (err) {

--- a/gui/src/pages/Court.tsx
+++ b/gui/src/pages/Court.tsx
@@ -111,6 +111,7 @@ export default function Court() {
   const [categories, setCategories] = useState<Category[]>([])
   const [selectedChannel, setSelectedChannel] = useState<string>('')
   const [botUserIds, setBotUserIds] = useState<Record<string, string>>({})
+  const [senderName, setSenderName] = useState(() => localStorage.getItem('court_sender_name') || '皇上')
   const logRef = useRef<HTMLDivElement>(null)
   const msgRef = useRef<HTMLDivElement>(null)
   const bg = theme === 'light' ? 'bg-white border border-gray-200' : 'bg-[#1a1a2e]'
@@ -175,7 +176,8 @@ export default function Court() {
           channel: activeChannel,
           message: command,
           botId: target,
-          mentionUserId
+          mentionUserId,
+          username: senderName || '皇上'
         })
       })
       const d = await r.json()
@@ -338,17 +340,33 @@ export default function Court() {
           </select>
         </div>
 
-        {/* 提示：选中bot时显示@mention信息 */}
-        {selectedBot && selectedBot !== 'main' && (
-          <div className={`text-[10px] ${sub} mb-2 flex items-center gap-1`}>
-            <span>💡</span>
-            <span>
-              将由司礼监在 #{discordChannels.find(c => c.id === activeChannel)?.name || '...'} 频道
-              @{bots.find(b => b.id === selectedBot)?.displayName} 发送
-              {botUserIds[selectedBot] ? '' : ' ⚠️ 未获取到bot ID，无法@mention'}
-            </span>
-          </div>
-        )}
+        {/* 身份设置 + 提示 */}
+        <div className={`text-[10px] ${sub} mb-2 flex items-center gap-1.5 flex-wrap`}>
+          <span>👤</span>
+          <span>身份：</span>
+          <input
+            type="text"
+            value={senderName}
+            onChange={e => {
+              setSenderName(e.target.value)
+              localStorage.setItem('court_sender_name', e.target.value)
+            }}
+            placeholder="皇上"
+            className={`text-[11px] w-20 px-1.5 py-0.5 rounded border ${
+              theme === 'light' ? 'bg-gray-50 border-gray-200' : 'bg-[#0d0d1a] border-[#d4a574]/20 text-[#e5e5e5]'
+            } focus:outline-none focus:border-[#d4a574]`}
+          />
+          {selectedBot && selectedBot !== 'main' && (
+            <>
+              <span>→</span>
+              <span>
+                将以「{senderName || '皇上'}」身份在 #{discordChannels.find(c => c.id === activeChannel)?.name || '...'}
+                @{bots.find(b => b.id === selectedBot)?.displayName}
+                {botUserIds[selectedBot] ? '' : ' ⚠️ 无法@mention'}
+              </span>
+            </>
+          )}
+        </div>
 
         <div className="flex flex-wrap gap-1.5 mb-3">
           {[


### PR DESCRIPTION
## 问题

之前下旨用主 bot 的 token 直接发消息，目标 bot 看到的是 **bot 发的消息**，可能因为 allowBots 配置或消息来源判断而不响应。

## 修复

改用 **Discord Webhook** 发送消息：

- Webhook 消息可以自定义 `username` 和 `avatar_url`
- 目标 bot 收到的不是 bot 消息，会正常响应 @mention
- 用户可以自定义发送身份（默认「皇上」）

### 工作流程

```
用户在 GUI 输入指令
  → 选择目标 bot + 频道
  → API 获取/创建该频道的 Webhook
  → 通过 Webhook 发送消息（显示为用户自定义的名字）
  → 消息内容包含 <@bot_user_id> 真正的 @mention
  → 目标 bot 收到 @mention，正常响应
```

### 技术细节

- `getOrCreateWebhook(channelId, botToken)` — 自动创建名为「AI朝廷-下旨」的 Webhook，带内存缓存
- Webhook 失效时自动清除缓存重试
- 身份名保存到 localStorage 持久化
- TypeScript + Node.js 语法检查通过