### PR TITLE
fix: 修复 GUI 认证令牌初始化错误

### DIFF
--- a/gui/server/index.js
+++ b/gui/server/index.js
@@ -16,6 +16,9 @@ const __dirname = dirname(__filename);
 const app = express();
 const PORT = process.env.BOLUO_GUI_PORT || 18795;
 
+// 必须在 getOrCreateAuthToken 之前定义 HOME，否则会导致变量初始化错误
+const HOME = process.env.HOME || '/home/ubuntu';
+
 // AUTH_TOKEN 管理：优先使用环境变量，否则从文件读取或生成新 token
 function getOrCreateAuthToken() {
   // 1. 检查环境变量
@@ -68,7 +71,6 @@ const AGENT_DEPT_MAP = {
   'yushanfang': '御膳房'
 };
 
-const HOME = process.env.HOME || '/home/ubuntu';
 const AGENTS_DIR = join(HOME, '.openclaw/agents');
 const CONFIG_PATH = join(HOME, '.openclaw/openclaw.json');
 


### PR DESCRIPTION
## 问题
GUI 服务器启动失败，抛出 `ReferenceError: Cannot access 'HOME' before initialization` 错误。

**根本原因:**
- `getOrCreateAuthToken()` 函数在第27行使用 `HOME` 变量
- 但 `HOME` 在第71行才定义
- 在第61行调用函数时，`HOME` 尚未初始化

## 修复
将 `HOME` 变量定义移至 `getOrCreateAuthToken()` 函数之前，确保变量在使用前已初始化。

**改动:**
- 在第18行添加 `HOME` 变量定义
- 删除第71行重复的 `HOME` 定义

## 测试
✅ 服务器正常启动  
✅ Token 文件成功创建到 `/root/.openclaw/gui-auth-token.txt`  
✅ 持久化 token 正常读取  
✅ Token: `504bc18ef53a0468f4f7fc87116717c3fc43551be984e392e169ed72b44fa2fe`

## 截图
服务器启动成功，显示认证令牌信息：
```
========================================
  🔐 GUI 认证令牌 (AUTH_TOKEN)
========================================
  来源: 持久化文件
  Token: 504bc18ef53a0468f4f7fc87116717c3fc43551be984e392e169ed72b44fa2fe
 
  💡 使用方法:
  在请求头中添加: Authorization: Bearer <token>
========================================
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)