### PR TITLE
fix(docs): Discord 配置字段 botName → name + 补充 @mention 格式说明

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -88,3 +88,18 @@ openclaw doctor
 ---
 
 ← [返回 README](../README.md)
+
+### Q: Bot 之间互相 @ 不触发回复？
+
+这是多 Bot 模式最常见的坑。Discord 的 @mention 必须用 `<@用户ID>` 格式（如 `<@1482327799279652974>`），纯文本 `@兵部` 只是普通字符串，不会触发任何通知。
+
+**解决方法**：在司礼监的 `identity.theme` 中写入每个 Bot 的 Discord User ID 和正确格式。详见 [Discord Bot 配置 - @mention 格式](./setup-discord.md#重要bot-互相-mention-的格式)。
+
+### Q: 日志显示 `no-mention` 但我确实 @ 了 Bot？
+
+`no-mention` 是正常行为 — 当一条消息 @司礼监 时，其他 6 个 Bot 都会报 `no-mention`（因为确实没 @ 它们）。只要被 @ 的那个 Bot 显示 `explicitlyMentioned=true` 就说明 mention 检测正常。
+
+如果被 @ 的 Bot 也报 `no-mention`，检查：
+1. 是否用了 `<@用户ID>` 格式（不是纯文本 `@名字`）
+2. `allowBots: true` 是否已配置（Bot 间互相触发需要）
+3. Bot 的 Message Content Intent 是否已开启

--- a/docs/setup-discord.md
+++ b/docs/setup-discord.md
@@ -84,12 +84,12 @@ nano ~/.openclaw/openclaw.json
       "allowBots": true,
       "accounts": {
         "silijian": {
-          "botName": "司礼监",
+          "name": "司礼监",
           "token": "这里粘贴司礼监的Token",
           "groupPolicy": "open"
         },
         "bingbu": {
-          "botName": "兵部",
+          "name": "兵部",
           "token": "这里粘贴兵部的Token",
           "groupPolicy": "open"
         }
@@ -168,3 +168,40 @@ journalctl --user -u openclaw-gateway --since "5 min ago"
 ---
 
 ← [返回 README](../README.md) | [进阶配置 →](./tutorial-advanced.md)
+
+## 重要：Bot 互相 @mention 的格式
+
+> ⚠️ 这是多 Bot 协作的**核心机制**，不了解会导致 Bot 之间完全无法互相触发。
+
+Discord 的 @mention 必须使用 `<@用户ID>` 格式，**纯文本 `@兵部` 不会触发任何通知**。
+
+### 为什么需要关注这个？
+
+司礼监的 `identity.theme` 里写着"@对应部门派活"，但 LLM 不知道其他 Bot 的 Discord User ID，只会输出纯文本 `@兵部` — 这在 Discord 里只是普通字符串，不会生成蓝色 mention，其他 Bot 完全收不到。
+
+### 怎么获取 Bot 的 User ID？
+
+1. 在 Discord 中开启「开发者模式」：用户设置 → 高级 → 开发者模式 ✅
+2. 右键点击 Bot 头像 → 「复制用户 ID」
+3. 得到一串数字（如 `1482327799279652974`）
+
+### 怎么配置？
+
+在司礼监的 `identity.theme` 中写入每个 Bot 的 Discord User ID：
+
+```
+【@mention 格式（最重要！）】
+在 Discord 中 @其他部门时，必须使用 <@数字ID> 格式：
+- 兵部 = <@这里填兵部的User ID>
+- 户部 = <@这里填户部的User ID>
+- 礼部 = <@这里填礼部的User ID>
+- 工部 = <@这里填工部的User ID>
+- 吏部 = <@这里填吏部的User ID>
+- 刑部 = <@这里填刑部的User ID>
+
+正确示例: <@1482327799279652974> 编写用户登录 REST API
+错误示例: @兵部 编写用户登录 REST API（对方收不到！）
+```
+
+> 💡 每个 Bot 的 User ID 在创建后就固定了，填一次即可。
+

--- a/docs/setup-feishu.md
+++ b/docs/setup-feishu.md
@@ -65,7 +65,7 @@ nano ~/.openclaw/openclaw.json
         "silijian": {
           "appId": "cli_你的AppID",
           "appSecret": "你的AppSecret",
-          "botName": "司礼监",
+          "name": "司礼监",
           "groupPolicy": "open"
         }
       }

--- a/install.sh
+++ b/install.sh
@@ -594,7 +594,7 @@ cat > "$CONFIG_DIR/openclaw.json" << FEISHU_EOF
         "silijian": {
           "appId": "YOUR_FEISHU_APP_ID",
           "appSecret": "YOUR_FEISHU_APP_SECRET",
-          "botName": "司礼监",
+          "name": "司礼监",
           "groupPolicy": "open"
         }
       }
@@ -725,52 +725,52 @@ cat > "$CONFIG_DIR/openclaw.json" << CONFIG_EOF
       "allowBots": true,
       "accounts": {
         "silijian": {
-          "botName": "司礼监",
+          "name": "司礼监",
           "token": "YOUR_SILIJIAN_BOT_TOKEN",
           "groupPolicy": "open"
         },
         "bingbu": {
-          "botName": "兵部",
+          "name": "兵部",
           "token": "YOUR_BINGBU_BOT_TOKEN",
           "groupPolicy": "open"
         },
         "hubu": {
-          "botName": "户部",
+          "name": "户部",
           "token": "YOUR_HUBU_BOT_TOKEN",
           "groupPolicy": "open"
         },
         "libu": {
-          "botName": "礼部",
+          "name": "礼部",
           "token": "YOUR_LIBU_BOT_TOKEN",
           "groupPolicy": "open"
         },
         "gongbu": {
-          "botName": "工部",
+          "name": "工部",
           "token": "YOUR_GONGBU_BOT_TOKEN",
           "groupPolicy": "open"
         },
         "libu2": {
-          "botName": "吏部",
+          "name": "吏部",
           "token": "YOUR_LIBU2_BOT_TOKEN",
           "groupPolicy": "open"
         },
         "xingbu": {
-          "botName": "刑部",
+          "name": "刑部",
           "token": "YOUR_XINGBU_BOT_TOKEN",
           "groupPolicy": "open"
         },
         "neige": {
-          "botName": "内阁",
+          "name": "内阁",
           "token": "YOUR_NEIGE_BOT_TOKEN",
           "groupPolicy": "open"
         },
         "duchayuan": {
-          "botName": "都察院",
+          "name": "都察院",
           "token": "YOUR_DUCHAYUAN_BOT_TOKEN",
           "groupPolicy": "open"
         },
         "hanlinyuan": {
-          "botName": "翰林院",
+          "name": "翰林院",
           "token": "YOUR_HANLINYUAN_BOT_TOKEN",
           "groupPolicy": "open"
         }

--- a/飞书配置指南.md
+++ b/飞书配置指南.md
@@ -147,7 +147,7 @@ openclaw channels add
         "silijian": {
           "appId": "cli_xxx",
           "appSecret": "你的App Secret",
-          "botName": "司礼监",
+          "name": "司礼监",
           "groupPolicy": "open"
         }
       }
@@ -254,7 +254,7 @@ feishu: account "silijian" ready
         "silijian": {
           "appId": "cli_你的司礼监AppId",
           "appSecret": "你的司礼监Secret",
-          "botName": "司礼监",
+          "name": "司礼监",
           "groupPolicy": "open"
         }
       }
@@ -322,13 +322,13 @@ feishu: account "silijian" ready
         "silijian": {
           "appId": "cli_司礼监的AppId",
           "appSecret": "司礼监的Secret",
-          "botName": "司礼监",
+          "name": "司礼监",
           "groupPolicy": "open"
         },
         "bingbu": {
           "appId": "cli_兵部的AppId",
           "appSecret": "兵部的Secret",
-          "botName": "兵部",
+          "name": "兵部",
           "groupPolicy": "open"
         }
       }
@@ -361,7 +361,7 @@ feishu: account "silijian" ready
         "silijian": {
           "appId": "cli_xxx",
           "appSecret": "xxx",
-          "botName": "司礼监",
+          "name": "司礼监",
           "groupPolicy": "open"
         }
       }


### PR DESCRIPTION
## 关联 Issue

Closes #83

## 问题

按照 `docs/setup-linux-discord.md` → `docs/setup-discord.md` 完整部署后，遇到两个文档级问题导致 Bot 无法正常互相协作：

### 1. `botName` vs `name` 字段不一致

`install.sh`、`setup-discord.md`、`setup-feishu.md`、`飞书配置指南.md` 中 Discord/飞书 accounts 使用 `botName` 字段，但 OpenClaw 框架实际读取 `name` 字段（`botName` 仅用于 Slack 模块），导致：
- `openclaw doctor` 报 `Unknown config keys: botName`
- Bot 显示名称可能回退到 key 名而非中文名

对比：`openclaw.example.json` 中已正确使用 `name`，但文档和脚本模板未同步。

### 2. Discord @mention 格式说明缺失

多 Bot 模式下 Bot 互相 @mention 必须使用 `<@用户ID>` 格式（如 `<@1482327799279652974>`），但教程从未提及此机制。司礼监的 `identity.theme` 写着"@对应部门派活"，LLM 不知道 Bot 的 Discord User ID，只会输出纯文本 `@兵部` — 在 Discord 里只是普通字符串，不会生成蓝色 mention，其他 Bot 完全收不到通知。

## 修改内容

| 文件 | 改动 |
|------|------|
| `install.sh` | Discord 和飞书模板中 `botName` → `name`（11 处） |
| `docs/setup-discord.md` | 示例中 `botName` → `name` + 新增「Bot 互相 @mention 的格式」章节 |
| `docs/setup-feishu.md` | 示例中 `botName` → `name` |
| `飞书配置指南.md` | 所有 `botName` → `name`（5 处） |
| `docs/faq.md` | 新增 Bot 互相 @mention 排查项 + `no-mention` 日志解释 |

## 测试

在 OpenClaw v2026.3.13 + 7 Bot Discord 环境中验证：
- 使用 `name` 字段后 `openclaw doctor` 不再报 Unknown config keys
- 在 `identity.theme` 中写入 `<@用户ID>` 后，司礼监能正确触发其他 Bot