### PR TITLE
fix(install): make install-lite rerunnable after interrupted setup

### DIFF
--- a/install-lite.sh
+++ b/install-lite.sh
@@ -12,6 +12,35 @@
 
 set -e
 
+
+# 保存终端状态，避免 read -s 被中断后出现“无回显/无反应”
+ORIGINAL_STTY_SETTINGS=""
+LOCK_FILE=""
+if [ -t 0 ] && command -v stty >/dev/null 2>&1; then
+    ORIGINAL_STTY_SETTINGS=$(stty -g 2>/dev/null || true)
+fi
+
+restore_terminal_state() {
+    if [ -n "$ORIGINAL_STTY_SETTINGS" ] && command -v stty >/dev/null 2>&1; then
+        stty "$ORIGINAL_STTY_SETTINGS" 2>/dev/null || stty echo 2>/dev/null || true
+    fi
+}
+cleanup_install_runtime() {
+    restore_terminal_state
+    if [ -n "$LOCK_FILE" ]; then
+        rm -f "$LOCK_FILE"
+    fi
+}
+
+handle_install_interrupt() {
+    cleanup_install_runtime
+    echo ""
+    echo "⚠ 安装已中断。可直接重新运行 install-lite.sh。"
+    exit 130
+}
+trap cleanup_install_runtime EXIT
+trap handle_install_interrupt INT TERM
+
 # 颜色定义
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -32,6 +61,34 @@ CONFIG_FILE="openclaw.json"
 
 # 创建配置目录
 mkdir -p "$CONFIG_DIR"
+
+# install-lite.sh 是交互式向导，非 TTY 环境下会出现“无响应/无输入”错觉
+if [ ! -t 0 ] || [ ! -t 1 ]; then
+    echo -e "${RED}✗ 当前不是交互式终端，install-lite.sh 需要可交互输入${NC}"
+    echo "请改用："
+    echo "  1) git clone 后本地执行：bash install-lite.sh"
+    echo "  2) 或使用支持交互的命令：bash <(curl -fsSL .../install-lite.sh)"
+    exit 1
+fi
+
+# 若上次被强制中断，优先恢复终端回显状态
+if [ -n "$ORIGINAL_STTY_SETTINGS" ]; then
+    stty echo 2>/dev/null || true
+fi
+
+# 防止并发执行；如果是陈旧锁文件则自动清理，确保可重入
+LOCK_FILE="$CONFIG_DIR/.install-lite.lock"
+if [ -f "$LOCK_FILE" ]; then
+    EXISTING_PID="$(cat "$LOCK_FILE" 2>/dev/null || true)"
+    if [ -n "$EXISTING_PID" ] && kill -0 "$EXISTING_PID" 2>/dev/null; then
+        echo -e "${RED}✗ 检测到 install-lite.sh 正在运行（PID: $EXISTING_PID）${NC}"
+        echo "请等待当前安装结束后再试。"
+        exit 1
+    fi
+    echo -e "${YELLOW}⚠ 检测到上次安装中断，正在恢复后重试...${NC}"
+    rm -f "$LOCK_FILE"
+fi
+echo "$$" > "$LOCK_FILE"
 
 # ========================================
 # 步骤 1: 配置 LLM API

--- a/tests/install-lite.test.js
+++ b/tests/install-lite.test.js
@@ -1,0 +1,41 @@
+const assert = require("assert");
+const fs = require("fs");
+const path = require("path");
+
+describe("install-lite.sh regression guards", () => {
+  const scriptPath = path.join(__dirname, "..", "install-lite.sh");
+  const scriptContent = fs.readFileSync(scriptPath, "utf8");
+
+  it("requires interactive TTY input to avoid non-responsive runs", () => {
+    assert(
+      /if \[ ! -t 0 \] \|\| \[ ! -t 1 \]/.test(scriptContent),
+      "install-lite.sh should guard against non-interactive stdin/stdout",
+    );
+  });
+
+  it("has stale-lock recovery and active-process detection for reruns", () => {
+    assert(
+      /LOCK_FILE="\$CONFIG_DIR\/\.install-lite\.lock"/.test(scriptContent),
+      "install-lite.sh should define a lock file",
+    );
+    assert(
+      /kill -0 "\$EXISTING_PID"/.test(scriptContent),
+      "install-lite.sh should detect active installer process by PID",
+    );
+  });
+
+  it("restores terminal state and clears runtime lock on interrupt/exit", () => {
+    assert(
+      /cleanup_install_runtime\(\)/.test(scriptContent),
+      "install-lite.sh should define cleanup_install_runtime",
+    );
+    assert(
+      /trap cleanup_install_runtime EXIT/.test(scriptContent),
+      "install-lite.sh should cleanup runtime state on EXIT",
+    );
+    assert(
+      /trap handle_install_interrupt INT TERM/.test(scriptContent),
+      "install-lite.sh should handle INT/TERM and restore terminal state",
+    );
+  });
+});


### PR DESCRIPTION
## 问题背景
Issue #132 反馈：`install-lite.sh` 在首次配置出错并强制退出（如 `Ctrl+C`）后，再次运行可能表现为“无回显/无反应”。

## 根因分析
- 脚本在中断场景下缺少统一清理，`read -s` 被打断后终端状态可能残留。
- 缺少对“并发运行 / 陈旧运行状态”的识别与恢复。
- 非交互终端执行时缺少明确提示，容易被误判为脚本卡死。

## 变更内容
### 1) `install-lite.sh`
- 增加终端状态保存与恢复逻辑（`stty`）。
- 增加统一清理函数，确保退出时恢复终端并清理运行锁。
- 增加 `INT/TERM/EXIT` trap，支持中断后可直接重跑。
- 增加交互终端检查（`-t 0` / `-t 1`），非交互场景快速失败并提示。
- 增加锁文件机制：`$CONFIG_DIR/.install-lite.lock`
  - 检测活跃安装进程，拒绝并发执行；
  - 检测陈旧锁并自动清理后继续执行。

### 2) `tests/install-lite.test.js`
新增回归测试，覆盖以下关键防护逻辑：
- 非交互 TTY 防护；
- 锁文件与 PID 检测；
- `EXIT/INT/TERM` 清理与恢复 trap。

## 验证
- `bash -n install-lite.sh` ✅
- `npx --yes jest tests/install-lite.test.js` ✅（1 suite, 3 tests passed）
- 手动中断重试场景验证：首次中断后可正常再次运行 ✅

## 风险评估
- 低风险：仅改动安装脚本与回归测试，不影响运行时业务逻辑。
- 行为变化：非交互环境会更早失败并给出明确提示（避免“无反应”误判）。

## 影响范围
- `install-lite.sh`
- `tests/install-lite.test.js`

## 关联 Issue
Closes #132

Co-Authored-By: Oz <oz-agent@warp.dev>
