### PR TITLE
feat: 适配 OpenClaw v2026.5.20 + Node.js 22.19 门槛

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # 📜 Changelog
 
+## v3.7.1 (2026-05-22)
+
+### OpenClaw 适配 v2026.5.20
+
+无破坏性变更,本次升级聚焦运行时门槛和新增可选字段。
+
+- **Node.js 最低版本 22.16 → 22.19** — 对齐上游 v2026.5.19 强制要求
+  - `install.ps1` — 版本探测改为同时校验 major+minor,Windows 安装器下载从 v22.14.0 升级到 v22.19.0
+  - `install-mac.sh` — Node 检测加入 minor 校验(>= 22.19),不达标自动 `brew install node@22` 升级
+  - `doctor.sh` — `[1/9]` 检查接受 `>= 22.19`,过低改为 warn 提示
+  - `package.json` — `engines.node` 由 `>=22.16.0` 提升到 `>=22.19.0`
+- **文档** — `EXTERNAL_HERMES.md`、`hermes.example.yaml`、`CONTRIBUTING.md` 版本占位符同步到 2026.5.20
+- **`docs/openclaw-upgrade-guide.md`** — 末尾新增 "升级到 2026.5.20" 一节,列出 v2026.5.8 ~ v2026.5.20 的新可选字段(`agents.list[].experimental.localModelLean`、`voice.realtime.bootstrapContextFiles`、`models.providers.<id>.timeoutSeconds`、`security.audit.suppressions`、Discord `agentComponents.ttlMs`、`tools.alsoAllow`)和 Docker 构建参数改名(`OPENCLAW_DOCKER_APT_PACKAGES` → `OPENCLAW_IMAGE_APT_PACKAGES`,新增 `OPENCLAW_IMAGE_PIP_PACKAGES`)
+
+> **现有用户**:已 work 的 `openclaw.json` 无需改动,只需把 Node 升到 22.19。
+
+---
+
 ## v3.7.0 (2026-05-10)
 
 ### 新功能 — 双 Agent Runtime 并行

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@
 
 ### 环境信息
 - OS: [如 Ubuntu 22.04]
-- OpenClaw 版本: [如 2026.3.13]
+- OpenClaw 版本: [如 2026.5.20]
 - 安装方式: [如 install-lite.sh]
 
 ### 截图

--- a/EXTERNAL_HERMES.md
+++ b/EXTERNAL_HERMES.md
@@ -193,8 +193,8 @@ echo "DISCORD_APPLICATION_ID=YOUR_APP_ID" >> ~/.hermes/.env
 hermes gateway restart
 ```
 
-OpenClaw v2026.5.x 起、Hermes v0.13.x 起,Discord slash 命令注册都要
-`applicationId`。danghuangshang `openclaw.example.json` 已对齐补全。
+OpenClaw v2026.5.x(已测到 v2026.5.20)起、Hermes v0.13.x 起,Discord slash
+命令注册都要 `applicationId`。danghuangshang `openclaw.example.json` 已对齐补全。
 
 ### 问题 3:模型 401 / 空回复
 

--- a/docs/openclaw-upgrade-guide.md
+++ b/docs/openclaw-upgrade-guide.md
@@ -258,11 +258,59 @@ openclaw gateway --verbose
 
 | OpenClaw 版本 | 配置格式 | 状态 |
 |--------------|---------|------|
-| 2026.3.13 | v2 | ✅ 当前版本 |
-| 2026.2.x | v1 | ⚠️ 需要升级 |
-| 2025.x | v0 | ❌ 不兼容 |
+| 2026.5.20 | v2 | ✅ 当前推荐 |
+| 2026.5.7  | v2 | ✅ 兼容(建议升级) |
+| 2026.3.13 | v2 | ✅ 兼容 |
+| 2026.2.x  | v1 | ⚠️ 需要升级 |
+| 2025.x    | v0 | ❌ 不兼容 |
 
 ---
 
-**最后更新**：2026-03-22  
-**适用版本**：OpenClaw 2026.3.13
+## 🆕 升级到 2026.5.20
+
+> 从 v2026.5.7 直接升级到 v2026.5.20 **无破坏性变更**,现有 `openclaw.json` 可直接使用。
+> 仅需把 Node.js 升到 22.19+。
+
+### 1. 运行时门槛
+
+- **Node.js 最低版本提升到 22.19**(v2026.5.19 强制)
+  - macOS:`brew install node@22 && brew link --overwrite node@22`
+  - Linux:`nvm install 22.19` 或 `n 22.19`
+  - Windows:下载 `https://nodejs.org/dist/v22.19.0/node-v22.19.0-x64.msi`
+  - 验证:`node -v` 应输出 `v22.19.x` 或更高
+
+### 2. 新增可选字段(均向后兼容,不加也能跑)
+
+| 字段 | 引入版本 | 用途 |
+|------|---------|------|
+| `agents.list[].experimental.localModelLean` | 2026.5.20 | 单 Agent 启用 lean local-model 模式 |
+| `voice.realtime.bootstrapContextFiles: []` | 2026.5.20 | Discord 语音会话:控制 profile context 注入 |
+| `models.providers.<id>.timeoutSeconds` | 2026.5.20 | 每 provider 的显式超时覆盖 |
+| `security.audit.suppressions` | 2026.5.17 | 显式接受的审计发现条目 |
+| `channels.discord.accounts[].agentComponents.ttlMs` | 2026.5.20 | Discord 回调注册的生命周期 |
+| `agents.list[].tools.alsoAllow` | 2026.5.17 | 单 Agent 的运行时工具白名单追加 |
+| `messages.groupChat.unmentionedInbound: "room_event"` | 2026.5.17 | 群聊中未 @ 你的消息以静默 context 形式注入 |
+| `gateway.remote.remotePort` | 2026.5.17 | Mac app 远程网关端口 |
+
+### 3. Docker 构建参数改名
+
+如果你写过自定义 Dockerfile 调用 OpenClaw 官方镜像基底:
+
+| 旧参数(legacy fallback) | 新参数 |
+|------------------------|--------|
+| `OPENCLAW_DOCKER_APT_PACKAGES` | `OPENCLAW_IMAGE_APT_PACKAGES` |
+| —(无) | `OPENCLAW_IMAGE_PIP_PACKAGES` |
+
+本项目自带的 `Dockerfile` 用 `apk add` 直装,**不受此改名影响**。
+
+### 4. 其他更新
+
+- xAI 支持 device-code OAuth(免 `XAI_API_KEY`,适合 headless 环境)
+- OpenRouter 现在尊重 provider 层 routing 策略
+- Codex 插件 CLI:`/codex plugins list | enable | disable`
+- 内置 Policy 插件用于频道合规检查
+
+---
+
+**最后更新**:2026-05-22
+**适用版本**:OpenClaw 2026.3.13 ~ 2026.5.20

--- a/doctor.sh
+++ b/doctor.sh
@@ -99,12 +99,15 @@ fi
 
 NODE_VER=$(node -v 2>/dev/null || echo "none")
 NODE_MAJOR=$(echo "$NODE_VER" | sed "s/v\([0-9]*\).*/\1/")
-if [ "${NODE_MAJOR:-0}" -ge 22 ] 2>/dev/null; then
+NODE_MINOR=$(echo "$NODE_VER" | sed "s/v[0-9]*\.\([0-9]*\).*/\1/")
+if [ "${NODE_MAJOR:-0}" -gt 22 ] 2>/dev/null; then
+    pass "Node.js $NODE_VER"
+elif [ "${NODE_MAJOR:-0}" -eq 22 ] && [ "${NODE_MINOR:-0}" -ge 19 ] 2>/dev/null; then
     pass "Node.js $NODE_VER"
 elif [[ "$NODE_VER" == "none" ]]; then
     fail "Node.js 未安装"
 else
-    warn "Node.js $NODE_VER — 推荐 v22+"
+    warn "Node.js $NODE_VER — OpenClaw v2026.5.19+ 要求 >= 22.19"
 fi
 
 # ---- [2/9] 检测配置文件 ----

--- a/hermes.example.yaml
+++ b/hermes.example.yaml
@@ -12,7 +12,7 @@
 #   ~/.hermes/personalities/*.md   (司礼监、内阁等角色提示词)
 #   ~/.hermes/context/AGENTS.md    (整个朝廷的全局 system prompt)
 #
-# 版本对齐: Hermes Agent v0.13.0 (v2026.5.7) 起的 schema。
+# 版本对齐: Hermes Agent v0.13.x (OpenClaw v2026.5.20) 起的 schema。
 # 官方完整字段: https://hermes-agent.nousresearch.com/docs/user-guide/configuration
 # =============================================================================
 

--- a/install-mac.sh
+++ b/install-mac.sh
@@ -66,19 +66,25 @@ else
 fi
 
 # ---- 2. Node.js ----
-echo -e "${YELLOW}[2/6] 检查 Node.js...${NC}"
-if command -v node &>/dev/null; then
-    NODE_MAJOR=$(node -v | sed 's/v\([0-9]*\).*/\1/')
-    if [ "$NODE_MAJOR" -ge 22 ] 2>/dev/null; then
-        echo -e "  ${GREEN}✓ Node.js $(node -v) 已安装${NC}"
-    else
-        echo -e "  ${YELLOW}⚠ Node.js $(node -v) 版本过低，升级中...${NC}"
-        brew install node@22
-        brew link --overwrite node@22 2>/dev/null || true
-        echo -e "  ${GREEN}✓ Node.js $(node -v) 安装完成${NC}"
-    fi
+# OpenClaw v2026.5.19 起强制要求 Node.js >= 22.19
+echo -e "${YELLOW}[2/6] 检查 Node.js (需 >= 22.19)...${NC}"
+node_meets_floor() {
+    local ver major minor
+    ver=$(node -v 2>/dev/null | sed 's/^v//') || return 1
+    major=${ver%%.*}
+    minor=${ver#*.}; minor=${minor%%.*}
+    [ "${major:-0}" -gt 22 ] && return 0
+    [ "${major:-0}" -eq 22 ] && [ "${minor:-0}" -ge 19 ] && return 0
+    return 1
+}
+if command -v node &>/dev/null && node_meets_floor; then
+    echo -e "  ${GREEN}✓ Node.js $(node -v) 已满足要求${NC}"
 else
-    echo -e "  ${CYAN}→ 安装 Node.js 22...${NC}"
+    if command -v node &>/dev/null; then
+        echo -e "  ${YELLOW}⚠ Node.js $(node -v) 版本过低 (需 >= 22.19)，升级中...${NC}"
+    else
+        echo -e "  ${CYAN}→ 安装 Node.js 22...${NC}"
+    fi
     brew install node@22
     brew link --overwrite node@22 2>/dev/null || true
     echo -e "  ${GREEN}✓ Node.js $(node -v) 安装完成${NC}"

--- a/install.ps1
+++ b/install.ps1
@@ -23,7 +23,7 @@ AI 朝廷 Windows 安装脚本
   - 网络连接
 
 安装内容:
-  - Node.js 22 LTS
+  - Node.js 22 LTS (>= 22.19, 满足 OpenClaw v2026.5.19+ 要求)
   - OpenClaw CLI
   - AI 朝廷配置文件
 
@@ -63,14 +63,16 @@ Write-Host ""
 # Node.js 检查与安装
 # ============================================
 function Test-NodeJs {
+    # OpenClaw v2026.5.19 起强制要求 Node.js >= 22.19
     try {
         $nodeVersion = node --version 2>&1
-        if ($nodeVersion -match 'v(\d+)\.') {
+        if ($nodeVersion -match 'v(\d+)\.(\d+)\.') {
             $majorVersion = [int]$matches[1]
-            if ($majorVersion -ge 22) {
+            $minorVersion = [int]$matches[2]
+            if ($majorVersion -gt 22 -or ($majorVersion -eq 22 -and $minorVersion -ge 19)) {
                 return $true
             } else {
-                Write-Warn "Node.js 版本过低：$nodeVersion (需要 v22+)"
+                Write-Warn "Node.js 版本过低：$nodeVersion (需要 >= v22.19)"
                 return $false
             }
         }
@@ -84,9 +86,9 @@ if (Test-NodeJs) {
     Write-Success "Node.js 已安装：$(node --version)"
 } else {
     Write-Info "正在安装 Node.js 22 LTS..."
-    
-    # 下载 Node.js 22 LTS 安装器
-    $installerUrl = "https://nodejs.org/dist/v22.14.0/node-v22.14.0-x64.msi"
+
+    # 下载 Node.js 22 LTS 安装器 (满足 OpenClaw >= 22.19 门槛)
+    $installerUrl = "https://nodejs.org/dist/v22.19.0/node-v22.19.0-x64.msi"
     $installerPath = "$env:TEMP\node-installer.msi"
     
     try {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawd",
-  "version": "3.6.0",
+  "version": "3.7.1",
   "description": "AI 朝廷 - 多 Agent 协作框架",
   "main": "index.js",
   "scripts": {
@@ -35,7 +35,7 @@
     "jest": "^30.3.0"
   },
   "engines": {
-    "node": ">=22.16.0"
+    "node": ">=22.19.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

把项目从 OpenClaw v2026.5.7 适配到最新 v2026.5.20。无破坏性变更,现有 `openclaw.json` 无需改动。

- **Node.js 最低 22.16 → 22.19**(对齐上游 v2026.5.19 强制要求)
- **文档版本占位符**统一刷到 2026.5.20
- **新增升级章节**汇总 v2026.5.8 ~ v2026.5.20 的所有新增可选字段和 Docker 构建参数改名

## 变更明细

| 文件 | 改动 |
|------|------|
| `install.ps1` | 版本探测加入 minor 校验;Windows 安装器 v22.14.0 → v22.19.0 |
| `install-mac.sh` | Node 检测函数化(`node_meets_floor`),需 >= 22.19 |
| `doctor.sh` | `[1/9]` Node 检查接受 22.19+ |
| `package.json` | `engines.node` >=22.16.0 → >=22.19.0;version 3.6.0 → 3.7.1 |
| `EXTERNAL_HERMES.md` / `hermes.example.yaml` / `CONTRIBUTING.md` | 版本占位符同步 |
| `CHANGELOG.md` | 新增 v3.7.1 entry |
| `docs/openclaw-upgrade-guide.md` | 末尾新增"升级到 2026.5.20"章节,列出新增可选字段(`agents.list[].experimental.localModelLean`、`voice.realtime.bootstrapContextFiles`、`models.providers.<id>.timeoutSeconds`、`security.audit.suppressions`、Discord `agentComponents.ttlMs`、`tools.alsoAllow` 等)和 `OPENCLAW_DOCKER_APT_PACKAGES` → `OPENCLAW_IMAGE_APT_PACKAGES` 改名 |

## Test plan

- [x] `bash -n install-mac.sh` / `bash -n doctor.sh` 语法通过
- [x] `package.json` / `openclaw.example.json` JSON 解析有效
- [x] `npm test` — 19/19 jest 用例通过
- [x] Node 版本检测逻辑 smoke test:`v22.19.0` pass、`v22.18.0` warn、`v22.20.5` pass、`v23.x` pass、`v20.x` warn、`none` fail
- [ ] (手测) Windows 上执行 `install.ps1`,看是否能从 v22.x → v22.19.x
- [ ] (手测) macOS 上 Node 22.16 跑 `install-mac.sh`,确认触发升级路径

https://claude.ai/code/session_01L2AJsVj62yfchX76wbnLrV

---
_Generated by [Claude Code](https://claude.ai/code/session_01L2AJsVj62yfchX76wbnLrV)_