### PR TITLE
feat(config): 新增 provider advisor，支持云端/本地模型分层推荐与一键应用

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "bin": {
     "task-store": "./scripts/task-store.js",
-    "context-compressor": "./scripts/context-compressor.js"
+    "context-compressor": "./scripts/context-compressor.js",
+    "provider-advisor": "./scripts/provider-advisor.js"
   },
   "keywords": [
     "ai",

--- a/scripts/provider-advisor.js
+++ b/scripts/provider-advisor.js
@@ -1,0 +1,241 @@
+#!/usr/bin/env node
+/**
+ * Provider Advisor - Agent Provider 分工建议与自动应用
+ *
+ * 用法：
+ *   node scripts/provider-advisor.js recommend --config openclaw.json
+ *   node scripts/provider-advisor.js recommend --config openclaw.json --apply
+ *   node scripts/provider-advisor.js recommend --config openclaw.json --apply --output new-openclaw.json
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const CRITICAL_AGENT_PATTERNS = [
+  /^silijian$/,
+  /^neige$/,
+  /^duchayuan$/,
+  /^bingbu$/,
+  /^hanlin_zhang$/
+];
+
+const OPERATION_AGENT_PATTERNS = [
+  /^libu$/,
+  /^libu2$/,
+  /^gongbu$/,
+  /^xingbu$/,
+  /^hubu$/,
+  /^qijuzhu$/,
+  /^guozijian$/,
+  /^taiyiyuan$/,
+  /^neiwufu$/,
+  /^yushanfang$/,
+  /^hanlin_/
+];
+
+function classifyAgentRole(agentId) {
+  if (!agentId) return 'operation';
+  if (CRITICAL_AGENT_PATTERNS.some((pattern) => pattern.test(agentId))) {
+    return 'critical';
+  }
+  if (OPERATION_AGENT_PATTERNS.some((pattern) => pattern.test(agentId))) {
+    return 'operation';
+  }
+  return 'operation';
+}
+
+function classifyProvider(providerId, provider) {
+  const source = `${providerId || ''} ${provider?.baseUrl || ''}`.toLowerCase();
+  const isLocal =
+    source.includes('localhost') ||
+    source.includes('127.0.0.1') ||
+    source.includes('0.0.0.0') ||
+    source.includes('11434') ||
+    source.includes('ollama') ||
+    source.includes('local');
+  return isLocal ? 'local' : 'cloud';
+}
+
+function scoreModel(model, role) {
+  const source = `${model?.id || ''} ${model?.name || ''}`.toLowerCase();
+  const strongPattern =
+    /(strong|reason|pro|ultra|opus|sonnet|gpt-4|gpt-5|claude|r1|70b|72b|32b|deep)/;
+  const fastPattern = /(fast|cheap|mini|small|lite|flash|haiku|8b|7b|3b|1\.5b)/;
+  const base = role === 'critical' ? 50 : 30;
+  const strongScore = strongPattern.test(source) ? 40 : 0;
+  const fastScore = fastPattern.test(source) ? 40 : 0;
+  const contextScore = Number(model?.contextWindow || 0) > 65536 ? 10 : 0;
+  const maxTokenScore = Number(model?.maxTokens || 0) > 4096 ? 5 : 0;
+  if (role === 'critical') {
+    return base + strongScore + contextScore + maxTokenScore - fastScore;
+  }
+  return base + fastScore + (strongScore > 0 ? -10 : 0);
+}
+
+function pickBestModel(provider, role) {
+  const models = provider?.models;
+  if (!Array.isArray(models) || models.length === 0) return null;
+  const sorted = [...models].sort((a, b) => scoreModel(b, role) - scoreModel(a, role));
+  return sorted[0];
+}
+
+function normalizeConfig(config) {
+  if (!config || typeof config !== 'object') {
+    throw new Error('Invalid config: expected object');
+  }
+  if (!config.models || typeof config.models !== 'object') {
+    throw new Error('Invalid config: missing models');
+  }
+  if (!config.models.providers || typeof config.models.providers !== 'object') {
+    throw new Error('Invalid config: missing models.providers');
+  }
+  if (!config.agents || typeof config.agents !== 'object' || !Array.isArray(config.agents.list)) {
+    throw new Error('Invalid config: missing agents.list');
+  }
+  return config;
+}
+
+function selectProviders(config) {
+  const providers = Object.entries(config.models.providers);
+  const localProviders = providers.filter(([providerId, provider]) => classifyProvider(providerId, provider) === 'local');
+  const cloudProviders = providers.filter(([providerId, provider]) => classifyProvider(providerId, provider) === 'cloud');
+  return {
+    local: localProviders[0] || null,
+    cloud: cloudProviders[0] || null
+  };
+}
+
+function recommendProviderSplit(config) {
+  normalizeConfig(config);
+  const selected = selectProviders(config);
+  const warnings = [];
+
+  if (!selected.cloud) {
+    warnings.push('No cloud provider detected; critical agents will keep existing model settings.');
+  }
+  if (!selected.local) {
+    warnings.push('No local provider detected; operation agents will fall back to cloud provider.');
+  }
+
+  const fallbackCloud = selected.cloud;
+  const effectiveLocal = selected.local || fallbackCloud;
+  const assignments = config.agents.list.map((agent) => {
+    const role = classifyAgentRole(agent.id);
+    const targetProviderTuple = role === 'critical' ? fallbackCloud : effectiveLocal;
+    if (!targetProviderTuple) {
+      return {
+        agentId: agent.id,
+        role,
+        currentModel: agent?.model?.primary || null,
+        recommendedModel: agent?.model?.primary || null,
+        changed: false,
+        reason: 'No provider available, keeping current model.'
+      };
+    }
+    const [providerId, providerConfig] = targetProviderTuple;
+    const selectedModel = pickBestModel(providerConfig, role);
+    if (!selectedModel) {
+      return {
+        agentId: agent.id,
+        role,
+        currentModel: agent?.model?.primary || null,
+        recommendedModel: agent?.model?.primary || null,
+        changed: false,
+        reason: `Provider ${providerId} has no models, keeping current model.`
+      };
+    }
+    const recommendedModel = `${providerId}/${selectedModel.id}`;
+    const currentModel = agent?.model?.primary || null;
+    return {
+      agentId: agent.id,
+      role,
+      currentModel,
+      recommendedModel,
+      changed: currentModel !== recommendedModel,
+      reason:
+        role === 'critical'
+          ? 'Critical agent uses stronger cloud model for planning/review quality.'
+          : 'Operation agent uses lower-cost local/fast model for routine tasks.'
+    };
+  });
+
+  return {
+    summary: {
+      cloudProvider: selected.cloud?.[0] || null,
+      localProvider: selected.local?.[0] || null,
+      totalAgents: assignments.length,
+      changes: assignments.filter((item) => item.changed).length
+    },
+    warnings,
+    assignments
+  };
+}
+
+function applyRecommendations(config, recommendations) {
+  const nextConfig = JSON.parse(JSON.stringify(config));
+  const byAgent = new Map(recommendations.assignments.map((item) => [item.agentId, item]));
+  nextConfig.agents.list = nextConfig.agents.list.map((agent) => {
+    const recommendation = byAgent.get(agent.id);
+    if (!recommendation || !recommendation.recommendedModel) return agent;
+    return {
+      ...agent,
+      model: {
+        ...(agent.model || {}),
+        primary: recommendation.recommendedModel
+      }
+    };
+  });
+  return nextConfig;
+}
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const command = args[0] || 'help';
+  const configIndex = args.indexOf('--config');
+  const outputIndex = args.indexOf('--output');
+  return {
+    command,
+    configPath: configIndex >= 0 ? args[configIndex + 1] : null,
+    outputPath: outputIndex >= 0 ? args[outputIndex + 1] : null,
+    apply: args.includes('--apply')
+  };
+}
+
+function runCli() {
+  const parsed = parseArgs(process.argv);
+  if (parsed.command !== 'recommend' || !parsed.configPath) {
+    console.log('Provider Advisor');
+    console.log('Usage: node scripts/provider-advisor.js recommend --config <openclaw.json> [--apply] [--output <file>]');
+    process.exit(parsed.command === 'help' ? 0 : 1);
+  }
+
+  const resolvedConfigPath = path.resolve(process.cwd(), parsed.configPath);
+  const raw = fs.readFileSync(resolvedConfigPath, 'utf8');
+  const config = JSON.parse(raw);
+  const recommendations = recommendProviderSplit(config);
+
+  if (!parsed.apply) {
+    console.log(JSON.stringify(recommendations, null, 2));
+    return;
+  }
+
+  const nextConfig = applyRecommendations(config, recommendations);
+  const outputPath = parsed.outputPath
+    ? path.resolve(process.cwd(), parsed.outputPath)
+    : resolvedConfigPath;
+  fs.writeFileSync(outputPath, JSON.stringify(nextConfig, null, 2) + '\n', 'utf8');
+  console.log(
+    `✅ Applied ${recommendations.summary.changes} model recommendation(s) to ${outputPath}`
+  );
+}
+
+if (require.main === module) {
+  runCli();
+}
+
+module.exports = {
+  classifyAgentRole,
+  classifyProvider,
+  recommendProviderSplit,
+  applyRecommendations
+};

--- a/tests/test-provider-advisor.test.js
+++ b/tests/test-provider-advisor.test.js
@@ -1,0 +1,103 @@
+const assert = require('assert');
+const {
+  classifyAgentRole,
+  classifyProvider,
+  recommendProviderSplit,
+  applyRecommendations
+} = require('../scripts/provider-advisor');
+
+function createConfig(overrides = {}) {
+  return {
+    models: {
+      providers: {
+        'cloud-primary': {
+          baseUrl: 'https://api.example.com/v1',
+          models: [
+            { id: 'fast-model', name: '快速模型', contextWindow: 8192, maxTokens: 2048 },
+            { id: 'strong-model', name: '强力模型', contextWindow: 200000, maxTokens: 8192 }
+          ]
+        },
+        'local-ollama': {
+          baseUrl: 'http://127.0.0.1:11434/v1',
+          models: [
+            { id: 'qwen2.5:14b', name: '本地中模型', contextWindow: 32768, maxTokens: 4096 },
+            { id: 'qwen2.5:7b', name: '本地轻模型', contextWindow: 32768, maxTokens: 2048 }
+          ]
+        }
+      }
+    },
+    agents: {
+      list: [
+        { id: 'neige', model: { primary: 'cloud-primary/fast-model' } },
+        { id: 'duchayuan', model: { primary: 'cloud-primary/fast-model' } },
+        { id: 'libu', model: { primary: 'cloud-primary/fast-model' } },
+        { id: 'gongbu', model: { primary: 'cloud-primary/fast-model' } }
+      ]
+    },
+    ...overrides
+  };
+}
+
+describe('Provider Advisor', () => {
+  it('classifies agent roles correctly', () => {
+    assert.strictEqual(classifyAgentRole('neige'), 'critical');
+    assert.strictEqual(classifyAgentRole('duchayuan'), 'critical');
+    assert.strictEqual(classifyAgentRole('gongbu'), 'operation');
+    assert.strictEqual(classifyAgentRole('unknown_agent'), 'operation');
+  });
+
+  it('classifies providers correctly', () => {
+    assert.strictEqual(
+      classifyProvider('local-ollama', { baseUrl: 'http://127.0.0.1:11434/v1' }),
+      'local'
+    );
+    assert.strictEqual(
+      classifyProvider('cloud-primary', { baseUrl: 'https://api.example.com/v1' }),
+      'cloud'
+    );
+  });
+
+  it('recommends cloud for critical and local for operation agents', () => {
+    const config = createConfig();
+    const result = recommendProviderSplit(config);
+    const byAgent = new Map(result.assignments.map((item) => [item.agentId, item]));
+
+    assert.strictEqual(result.summary.cloudProvider, 'cloud-primary');
+    assert.strictEqual(result.summary.localProvider, 'local-ollama');
+    assert.strictEqual(byAgent.get('neige').recommendedModel, 'cloud-primary/strong-model');
+    assert.strictEqual(byAgent.get('duchayuan').recommendedModel, 'cloud-primary/strong-model');
+    assert.strictEqual(byAgent.get('libu').recommendedModel, 'local-ollama/qwen2.5:7b');
+    assert.strictEqual(byAgent.get('gongbu').recommendedModel, 'local-ollama/qwen2.5:7b');
+  });
+
+  it('falls back to cloud when no local provider exists', () => {
+    const config = createConfig({
+      models: {
+        providers: {
+          'cloud-primary': {
+            baseUrl: 'https://api.example.com/v1',
+            models: [{ id: 'strong-model', name: '强力模型', contextWindow: 200000, maxTokens: 8192 }]
+          }
+        }
+      }
+    });
+    const result = recommendProviderSplit(config);
+    const libu = result.assignments.find((item) => item.agentId === 'libu');
+
+    assert(result.warnings.some((item) => item.includes('No local provider detected')));
+    assert.strictEqual(libu.recommendedModel, 'cloud-primary/strong-model');
+  });
+
+  it('applies recommendations without mutating original config', () => {
+    const config = createConfig();
+    const result = recommendProviderSplit(config);
+    const updated = applyRecommendations(config, result);
+    const oldNeige = config.agents.list.find((item) => item.id === 'neige');
+    const newNeige = updated.agents.list.find((item) => item.id === 'neige');
+    const newLibu = updated.agents.list.find((item) => item.id === 'libu');
+
+    assert.strictEqual(oldNeige.model.primary, 'cloud-primary/fast-model');
+    assert.strictEqual(newNeige.model.primary, 'cloud-primary/strong-model');
+    assert.strictEqual(newLibu.model.primary, 'local-ollama/qwen2.5:7b');
+  });
+});


### PR DESCRIPTION


## 问题背景
当前配置通常是“所有 agent 共用同一 provider / model”，在实际使用中会出现两个问题：



### 1) 新增脚本：`scripts/provider-advisor.js`
- 支持读取并分析现有配置（providers + agents）
- 对 agent 角色做分类（如关键决策类 / 执行操作类）
- 对 provider 做分类（云端 / 本地）
- 输出推荐策略：
  - 关键类 agent 优先云端模型
  - 操作类 agent 优先本地模型
  - 若不存在本地 provider，自动回退云端（保证可用性）
- 支持两种模式：
  - `recommend`：仅输出建议，不改文件
  - `recommend --apply`：将建议写回配置文件

### 2) 新增测试：`tests/test-provider-advisor.test.js`
覆盖以下核心行为：
1. agent 角色分类正确
2. provider 分类正确
3. 云/本地混合场景推荐正确（关键走云，操作走本地）
4. 无本地 provider 时回退云端
5. `--apply` 行为正确且不污染原始对象（避免隐式副作用）

### 3) 命令入口更新：`package.json`
- 新增 bin 映射：
  - `"provider-advisor": "./scripts/provider-advisor.js"`

## 影响范围
- `package.json`
- `scripts/provider-advisor.js`（新增）
- `tests/test-provider-advisor.test.js`（新增）

## 测试结果
执行命令：

```bash
npm --prefix /home/calelin/dev/danghuangshang test -- tests/test-provider-advisor.test.js
```

结果：
- Test Suites: **1 passed**, 1 total
- Tests: **5 passed**, 5 total
